### PR TITLE
Backend environment configuration

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -6,6 +6,21 @@ These are the different APIs that each handle a separate portion of the app.
   - User login/logout
   - Modification of user account
   - Validates authentication tokens
+- [Users](users)
+  - Register a user
+  - Modify a user's information
+  - Search for users by username
+- [Chats](chats)
+  - Create a chat with specified users
+  - Manage users in a chat
+  - Delete a chat
 - [Messages](messages)
-  - Send messages to user
-  - Recieve message from user
+  - Send messages to a chat
+  - Receive message from a chat
+  - Modify a message in a chat
+- [Files](files)
+  - Upload a file for a message
+  - Download a file from a message
+- [WebSockets](websockets)
+  - Send a message in real-time
+  - Get notified of a message in real-time

--- a/api/authentication/README.md
+++ b/api/authentication/README.md
@@ -1,2 +1,0 @@
-# Authentication API
-This API handles user authentication, profile editing, and token verification.

--- a/api/chats/README.md
+++ b/api/chats/README.md
@@ -1,2 +1,0 @@
-# Chat API
-This API handles chat creation, modification, and deletion.

--- a/api/init.go
+++ b/api/init.go
@@ -49,6 +49,7 @@ func init() {
 	if err := viper.ReadInConfig(); err != nil {
 		switch err.(type) {
 		case viper.ConfigFileNotFoundError:
+		case *os.PathError:
 			logrus.WithField("app", "initialization").Info("Configuration file not found, continuing with defaults and environment variables")
 		default:
 			logrus.WithField("app", "initialization").WithError(err).Fatal("Failed to parse configuration file")

--- a/api/init.go
+++ b/api/init.go
@@ -49,12 +49,11 @@ func init() {
 	if err := viper.ReadInConfig(); err != nil {
 		switch err.(type) {
 		case viper.ConfigFileNotFoundError:
-			logrus.WithField("app", "initialization").WithError(err).Fatal("Configuration file not found")
+			logrus.WithField("app", "initialization").Info("Configuration file not found, continuing with defaults and environment variables")
 		default:
 			logrus.WithField("app", "initialization").WithError(err).Fatal("Failed to parse configuration file")
 		}
 	}
-	logrus.WithField("app", "initialization").Trace("Successfully parsed configuration file")
 
 	// Validate ssl mode
 	if mode := viper.GetString("database.ssl"); mode != "disable" && mode != "allow" && mode != "prefer" && mode != "require" && mode != "verify-ca" && mode != "verify-full" {

--- a/api/init.go
+++ b/api/init.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"os"
+	"strings"
 )
 
 func init() {
@@ -38,6 +39,11 @@ func init() {
 	viper.SetDefault("database.ssl", "disable")
 	viper.SetDefault("database.reset", false)
 	logrus.WithField("app", "initialization").Trace("Set defaults for configuration keys")
+
+	// Allow loading config from environment variables
+	viper.SetEnvPrefix("chat")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
 
 	// Parse configuration file
 	if err := viper.ReadInConfig(); err != nil {

--- a/api/messages/README.md
+++ b/api/messages/README.md
@@ -1,2 +1,0 @@
-# Message API
-This API handles message creation, modification, and deletion for a given chat.


### PR DESCRIPTION
Allow the API to be configured through environment variables. Every environment variable must be prefixed with `CHAT_` and the `.` separators for nested keys will also be replaced with `_`.